### PR TITLE
feat(clojure): Add tree-sitter Clojure mapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "tree-sitter": "0.22.4",
+        "tree-sitter-clojure": "github:ghoseb/tree-sitter-clojure",
         "tree-sitter-cpp": "0.23.4",
         "tree-sitter-rust": "0.23.3",
         "ts-morph": "27.0.2"
@@ -12492,6 +12493,23 @@
       "peerDependenciesMeta": {
         "tree-sitter": {
           "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-clojure": {
+      "version": "0.0.14",
+      "resolved": "git+ssh://git@github.com/ghoseb/tree-sitter-clojure.git#78928e6e59734bf6c182283b26b93b78d0e6c840",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.4"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": false
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "license": "MIT",
   "dependencies": {
     "tree-sitter": "0.22.4",
+    "tree-sitter-clojure": "github:ghoseb/tree-sitter-clojure",
     "tree-sitter-cpp": "0.23.4",
     "tree-sitter-rust": "0.23.3",
     "ts-morph": "27.0.2"

--- a/src/language-detect.ts
+++ b/src/language-detect.ts
@@ -38,6 +38,12 @@ const EXTENSION_MAP: Record<string, LanguageInfo> = {
   ".hpp": { id: "cpp", name: "C++" },
   ".hxx": { id: "cpp", name: "C++" },
 
+  // Clojure
+  ".clj": { id: "clojure", name: "Clojure" },
+  ".cljs": { id: "clojure", name: "ClojureScript" },
+  ".cljc": { id: "clojure", name: "Clojure" },
+  ".edn": { id: "clojure", name: "EDN" },
+
   // SQL
   ".sql": { id: "sql", name: "SQL" },
 

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -3,6 +3,7 @@ import type { FileMap, MapOptions } from "./types.js";
 import { THRESHOLDS } from "./constants.js";
 import { detectLanguage } from "./language-detect.js";
 import { cMapper } from "./mappers/c.js";
+import { clojureMapper } from "./mappers/clojure.js";
 import { cppMapper } from "./mappers/cpp.js";
 import { csvMapper } from "./mappers/csv.js";
 import { ctagsMapper } from "./mappers/ctags.js";
@@ -57,6 +58,9 @@ const MAPPERS: Record<string, MapperFn> = {
   yaml: yamlMapper,
   toml: tomlMapper,
   csv: csvMapper,
+
+  // Phase 5: Clojure tree-sitter
+  clojure: clojureMapper,
 };
 
 /**

--- a/src/mappers/clojure.ts
+++ b/src/mappers/clojure.ts
@@ -1,0 +1,614 @@
+import { readFile, stat } from "node:fs/promises";
+/**
+ * Clojure mapper using tree-sitter for AST extraction.
+ *
+ * The tree-sitter-clojure grammar parses at the S-expression level:
+ * all forms are `list_lit` nodes. We identify def forms by matching
+ * the first `sym_lit` child against known Clojure special forms.
+ */
+import { createRequire } from "node:module";
+
+import type { FileMap, FileSymbol } from "../types.js";
+
+import { DetailLevel, SymbolKind } from "../enums.js";
+
+type SyntaxNode = import("tree-sitter").SyntaxNode;
+
+/**
+ * Def forms we recognize and how they map to symbol kinds.
+ */
+const DEF_FORMS: Record<
+  string,
+  { kind: SymbolKind; isPrivate?: boolean; hasChildren?: boolean }
+> = {
+  defn: { kind: SymbolKind.Function },
+  "defn-": { kind: SymbolKind.Function, isPrivate: true },
+  def: { kind: SymbolKind.Variable },
+  defonce: { kind: SymbolKind.Variable },
+  defmacro: { kind: SymbolKind.Function },
+  defmulti: { kind: SymbolKind.Function },
+  defmethod: { kind: SymbolKind.Method },
+  defprotocol: { kind: SymbolKind.Interface, hasChildren: true },
+  defrecord: { kind: SymbolKind.Class, hasChildren: true },
+  deftype: { kind: SymbolKind.Class, hasChildren: true },
+};
+
+// Lazy-loaded parser
+let parser: import("tree-sitter") | null = null;
+let parserInitialized = false;
+
+function ensureWritableTypeProperty(parserCtor: unknown): void {
+  const syntaxNode = (parserCtor as { SyntaxNode?: { prototype?: object } })
+    .SyntaxNode;
+  const proto = syntaxNode?.prototype;
+  if (!proto) {
+    return;
+  }
+  const desc = Object.getOwnPropertyDescriptor(proto, "type");
+  if (!desc || desc.set) {
+    return;
+  }
+  Object.defineProperty(proto, "type", { ...desc, set: () => {} });
+}
+
+function getParser(): import("tree-sitter") | null {
+  if (parserInitialized) {
+    return parser;
+  }
+
+  parserInitialized = true;
+
+  const isBun = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
+  if (isBun) {
+    return null;
+  }
+
+  try {
+    const require = createRequire(import.meta.url);
+    const ParserCtor = require("tree-sitter") as typeof import("tree-sitter");
+    const Clojure =
+      require("tree-sitter-clojure") as import("tree-sitter").Language;
+    ensureWritableTypeProperty(ParserCtor);
+    parser = new ParserCtor();
+    parser.setLanguage(Clojure);
+    return parser;
+  } catch {
+    return null;
+  }
+}
+
+function getNodeText(node: SyntaxNode, source: string): string {
+  return source.slice(node.startIndex, node.endIndex);
+}
+
+/**
+ * Get the text of a sym_lit's sym_name child.
+ */
+function getSymName(node: SyntaxNode, source: string): string | null {
+  if (node.type !== "sym_lit") {
+    return null;
+  }
+  const nameNode = node.namedChildren.find((c) => c.type === "sym_name");
+  if (!nameNode) {
+    return null;
+  }
+  return getNodeText(nameNode, source);
+}
+
+/**
+ * Check if a sym_lit has ^:private metadata.
+ */
+function hasPrivateMeta(node: SyntaxNode): boolean {
+  return node.namedChildren.some(
+    (c) =>
+      c.type === "meta_lit" &&
+      c.namedChildren.some((v) => v.type === "kwd_lit" && v.text === ":private")
+  );
+}
+
+/**
+ * Extract the string content from a str_lit node (strips surrounding quotes).
+ */
+function extractString(node: SyntaxNode, source: string): string {
+  const text = getNodeText(node, source);
+  return text.slice(1, -1);
+}
+
+/**
+ * Extract the named values from a list_lit (skipping gaps/whitespace).
+ */
+function getValueChildren(node: SyntaxNode): SyntaxNode[] {
+  return node.namedChildren.filter(
+    (c) => c.type !== "comment" && c.type !== "dis_expr"
+  );
+}
+
+/**
+ * Extract protocol method signatures from a defprotocol body.
+ */
+function extractProtocolMethods(
+  children: SyntaxNode[],
+  source: string
+): FileSymbol[] {
+  const methods: FileSymbol[] = [];
+  for (const child of children) {
+    if (child.type !== "list_lit") {
+      continue;
+    }
+    const values = getValueChildren(child);
+    const [firstValue] = values;
+    if (!firstValue || firstValue.type !== "sym_lit") {
+      continue;
+    }
+    const name = getSymName(firstValue, source);
+    if (!name) {
+      continue;
+    }
+
+    const paramsNode = values.find((v) => v.type === "vec_lit");
+    const params = paramsNode ? getNodeText(paramsNode, source) : "";
+    const signature = params ? `(${name} ${params})` : `(${name})`;
+
+    const docNode = values.find(
+      (v, i) =>
+        v.type === "str_lit" && i > values.indexOf(paramsNode ?? firstValue)
+    );
+
+    methods.push({
+      name,
+      kind: SymbolKind.Method,
+      startLine: child.startPosition.row + 1,
+      endLine: child.endPosition.row + 1,
+      signature,
+      ...(docNode ? { docstring: extractString(docNode, source) } : {}),
+    });
+  }
+  return methods;
+}
+
+/**
+ * Extract a defmethod form into an ExtractedDef-like result.
+ */
+function extractDefmethod(
+  node: SyntaxNode,
+  values: SyntaxNode[],
+  source: string
+): FileSymbol | null {
+  const [, nameNode, dispatchNode] = values;
+  if (!nameNode || nameNode.type !== "sym_lit") {
+    return null;
+  }
+  const multiName = getSymName(nameNode, source);
+  if (!multiName) {
+    return null;
+  }
+
+  const dispatchVal = dispatchNode
+    ? getNodeText(dispatchNode, source)
+    : "unknown";
+
+  const paramsNode = values.find((v) => v.type === "vec_lit");
+  const params = paramsNode ? getNodeText(paramsNode, source) : "";
+  const signature = `(defmethod ${multiName} ${dispatchVal} ${params})`;
+
+  return {
+    name: `${multiName} ${dispatchVal}`,
+    kind: SymbolKind.Method,
+    startLine: node.startPosition.row + 1,
+    endLine: node.endPosition.row + 1,
+    signature,
+    isExported: true,
+  };
+}
+
+/**
+ * Extract docstring from values after the name.
+ *
+ * For function-like forms (defn, defmacro, defprotocol, defmulti):
+ *   docstring is the first str_lit that appears before any vec_lit or list_lit.
+ *
+ * For value forms (def, defonce):
+ *   a str_lit is a docstring only if another value follows it.
+ *   e.g. (def x "doc" 42) → docstring="doc", but (def x "val") → no docstring.
+ */
+function extractDocstring(
+  restValues: SyntaxNode[],
+  source: string,
+  isValueForm: boolean
+): string | undefined {
+  const firstStr = restValues.find((v) => v.type === "str_lit");
+  if (!firstStr) {
+    return undefined;
+  }
+  const firstVec = restValues.find((v) => v.type === "vec_lit");
+  const firstList = restValues.find((v) => v.type === "list_lit");
+
+  const strIdx = restValues.indexOf(firstStr);
+  const vecIdx = firstVec ? restValues.indexOf(firstVec) : Infinity;
+  const listIdx = firstList ? restValues.indexOf(firstList) : Infinity;
+
+  if (strIdx >= vecIdx || strIdx >= listIdx) {
+    return undefined;
+  }
+
+  // For def/defonce: the string is a docstring only if a value follows it
+  if (isValueForm) {
+    const hasValueAfter = restValues.some(
+      (v, i) => i > strIdx && v.type !== "comment" && v.type !== "dis_expr"
+    );
+    if (!hasValueAfter) {
+      return undefined;
+    }
+  }
+
+  return extractString(firstStr, source);
+}
+
+/**
+ * Build signature for function-like forms (defn, defn-, defmacro).
+ */
+function buildFnSignature(
+  formName: string,
+  name: string,
+  restValues: SyntaxNode[],
+  source: string
+): string {
+  const firstVec = restValues.find((v) => v.type === "vec_lit");
+  if (firstVec) {
+    return `(${formName} ${name} ${getNodeText(firstVec, source)})`;
+  }
+
+  // Multi-arity: look for list_lit children starting with vec_lit
+  const arities = restValues.filter(
+    (v) =>
+      v.type === "list_lit" &&
+      getValueChildren(v).some((c) => c.type === "vec_lit")
+  );
+  if (arities.length > 0) {
+    const arityStrs = arities.map((a) => {
+      const vec = getValueChildren(a).find((c) => c.type === "vec_lit");
+      return vec ? getNodeText(vec, source) : "[]";
+    });
+    return `(${formName} ${name} ${arityStrs.join(" ")})`;
+  }
+
+  return `(${formName} ${name})`;
+}
+
+/**
+ * Build signature for non-function def forms.
+ */
+function buildDefSignature(
+  formName: string,
+  name: string,
+  restValues: SyntaxNode[],
+  source: string
+): string {
+  if (formName === "defmulti") {
+    const dispatchNode = restValues.find((v) => v.type !== "str_lit");
+    const dispatch = dispatchNode ? getNodeText(dispatchNode, source) : "";
+    return dispatch ? `(defmulti ${name} ${dispatch})` : `(defmulti ${name})`;
+  }
+
+  if (formName === "defprotocol") {
+    return `(defprotocol ${name})`;
+  }
+
+  if (formName === "defrecord" || formName === "deftype") {
+    const firstVec = restValues.find((v) => v.type === "vec_lit");
+    return firstVec
+      ? `(${formName} ${name} ${getNodeText(firstVec, source)})`
+      : `(${formName} ${name})`;
+  }
+
+  // def, defonce
+  return `(${formName} ${name})`;
+}
+
+const FN_FORMS = new Set(["defn", "defn-", "defmacro"]);
+
+/**
+ * Try to extract a def form from a list_lit node.
+ */
+function extractDef(node: SyntaxNode, source: string): FileSymbol | null {
+  if (node.type !== "list_lit") {
+    return null;
+  }
+
+  const values = getValueChildren(node);
+  if (values.length < 2) {
+    return null;
+  }
+
+  const [formNode, nameNode] = values;
+  if (!formNode || formNode.type !== "sym_lit") {
+    return null;
+  }
+  const formName = getSymName(formNode, source);
+  if (!formName) {
+    return null;
+  }
+
+  const defInfo = DEF_FORMS[formName];
+  if (!defInfo) {
+    return null;
+  }
+
+  // defmethod has unique structure
+  if (formName === "defmethod") {
+    return extractDefmethod(node, values, source);
+  }
+
+  if (!nameNode || nameNode.type !== "sym_lit") {
+    return null;
+  }
+  const name = getSymName(nameNode, source);
+  if (!name) {
+    return null;
+  }
+
+  const isPrivate = defInfo.isPrivate === true || hasPrivateMeta(nameNode);
+  const modifiers: string[] = [];
+  if (isPrivate) {
+    modifiers.push("private");
+  }
+  if (formName === "defmacro") {
+    modifiers.push("macro");
+  }
+
+  const restValues = values.slice(2);
+  const isValueForm = formName === "def" || formName === "defonce";
+  const docstring = extractDocstring(restValues, source, isValueForm);
+
+  const signature = FN_FORMS.has(formName)
+    ? buildFnSignature(formName, name, restValues, source)
+    : buildDefSignature(formName, name, restValues, source);
+
+  let children: FileSymbol[] | undefined;
+  if (defInfo.hasChildren && formName === "defprotocol") {
+    const extracted = extractProtocolMethods(restValues, source);
+    children = extracted.length > 0 ? extracted : undefined;
+  }
+
+  const symbol: FileSymbol = {
+    name,
+    kind: defInfo.kind,
+    startLine: node.startPosition.row + 1,
+    endLine: node.endPosition.row + 1,
+    isExported: !isPrivate,
+  };
+
+  if (signature) {
+    symbol.signature = signature;
+  }
+  if (docstring) {
+    symbol.docstring = docstring;
+  }
+  if (modifiers.length > 0) {
+    symbol.modifiers = modifiers;
+  }
+  if (children) {
+    symbol.children = children;
+  }
+
+  return symbol;
+}
+
+/**
+ * Extract ns form for namespace and imports.
+ */
+function extractNs(
+  node: SyntaxNode,
+  source: string
+): { namespace: string; imports: string[]; docstring?: string } | null {
+  if (node.type !== "list_lit") {
+    return null;
+  }
+
+  const values = getValueChildren(node);
+  if (values.length < 2) {
+    return null;
+  }
+
+  const [formNode, nameNode, docNode] = values;
+  if (!formNode || formNode.type !== "sym_lit") {
+    return null;
+  }
+  if (getSymName(formNode, source) !== "ns") {
+    return null;
+  }
+
+  if (!nameNode || nameNode.type !== "sym_lit") {
+    return null;
+  }
+  const namespace = getSymName(nameNode, source);
+  if (!namespace) {
+    return null;
+  }
+
+  // Docstring at index 2
+  let docstring: string | undefined;
+  if (docNode?.type === "str_lit") {
+    docstring = extractString(docNode, source);
+  }
+
+  // Extract :require and :import clauses
+  const imports: string[] = [];
+  for (const child of values) {
+    if (child.type !== "list_lit") {
+      continue;
+    }
+    const listValues = getValueChildren(child);
+    const [kwd] = listValues;
+    if (!kwd || kwd.type !== "kwd_lit") {
+      continue;
+    }
+    const kwdText = getNodeText(kwd, source);
+    if (kwdText === ":require" || kwdText === ":import") {
+      for (const spec of listValues.slice(1)) {
+        // Unwrap reader conditionals inside require/import:
+        // #?(:clj [clojure.java.io] :cljs [cljs.reader])
+        // → each platform's specs get added with a platform tag
+        if (
+          spec.type === "read_cond_lit" ||
+          spec.type === "splicing_read_cond_lit"
+        ) {
+          const rcChildren = getValueChildren(spec);
+          let platform: string | undefined;
+          for (const rc of rcChildren) {
+            if (rc.type === "kwd_lit") {
+              platform = getNodeText(rc, source);
+              continue;
+            }
+            if (platform) {
+              imports.push(`${getNodeText(rc, source)} ${platform}`);
+              platform = undefined;
+            }
+          }
+        } else {
+          imports.push(getNodeText(spec, source));
+        }
+      }
+    }
+  }
+
+  return { namespace, imports, docstring };
+}
+
+/**
+ * Extract def forms from a reader conditional (#? or #?@).
+ *
+ * Reader conditionals contain kwd_lit/form pairs like:
+ *   #?(:clj (defn foo [x] ...) :cljs (defn foo [x] ...))
+ *
+ * We extract defs from all platform branches, annotating each with
+ * its platform keyword as a modifier. When the same name appears in
+ * multiple branches, all variants are included — the map consumer
+ * sees the full picture.
+ */
+function extractReaderConditionalDefs(
+  node: SyntaxNode,
+  source: string
+): FileSymbol[] {
+  const results: FileSymbol[] = [];
+  const children = getValueChildren(node);
+
+  // Children alternate: kwd_lit, form, kwd_lit, form, ...
+  let currentPlatform: string | undefined;
+  for (const child of children) {
+    if (child.type === "kwd_lit") {
+      currentPlatform = getNodeText(child, source);
+      continue;
+    }
+
+    if (child.type === "list_lit") {
+      const def = extractDef(child, source);
+      if (def && currentPlatform) {
+        const platformMod = `platform:${currentPlatform}`;
+        def.modifiers = def.modifiers
+          ? [...def.modifiers, platformMod]
+          : [platformMod];
+        results.push(def);
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Generate a file map for Clojure files using tree-sitter.
+ */
+export async function clojureMapper(
+  filePath: string,
+  signal?: AbortSignal
+): Promise<FileMap | null> {
+  try {
+    if (!getParser()) {
+      return null;
+    }
+
+    const stats = await stat(filePath);
+    const totalBytes = stats.size;
+
+    const content = await readFile(filePath, "utf8");
+
+    if (signal?.aborted) {
+      return null;
+    }
+
+    const p = getParser();
+    if (!p) {
+      return null;
+    }
+
+    let tree: import("tree-sitter").Tree;
+    try {
+      tree = p.parse(content);
+    } catch {
+      return null;
+    }
+
+    const symbols: FileSymbol[] = [];
+    const imports: string[] = [];
+
+    for (const child of tree.rootNode.namedChildren) {
+      // Reader conditionals: extract defs from all platform branches
+      if (
+        child.type === "read_cond_lit" ||
+        child.type === "splicing_read_cond_lit"
+      ) {
+        const condDefs = extractReaderConditionalDefs(child, content);
+        symbols.push(...condDefs);
+        continue;
+      }
+
+      if (child.type !== "list_lit") {
+        continue;
+      }
+
+      const ns = extractNs(child, content);
+      if (ns) {
+        imports.push(...ns.imports);
+
+        symbols.push({
+          name: ns.namespace,
+          kind: SymbolKind.Namespace,
+          startLine: child.startPosition.row + 1,
+          endLine: child.endPosition.row + 1,
+          signature: `(ns ${ns.namespace})`,
+          ...(ns.docstring ? { docstring: ns.docstring } : {}),
+          isExported: true,
+        });
+        continue;
+      }
+
+      const def = extractDef(child, content);
+      if (def) {
+        symbols.push(def);
+      }
+    }
+
+    if (symbols.length === 0) {
+      return null;
+    }
+
+    const totalLines = content.split("\n").length;
+
+    return {
+      path: filePath,
+      totalLines,
+      totalBytes,
+      language: "Clojure",
+      symbols,
+      imports,
+      detailLevel: DetailLevel.Full,
+    };
+  } catch (error) {
+    if (signal?.aborted) {
+      return null;
+    }
+    console.error(`Clojure mapper failed: ${error}`);
+    return null;
+  }
+}

--- a/tests/fixtures/clojure/reader_cond.cljc
+++ b/tests/fixtures/clojure/reader_cond.cljc
@@ -1,0 +1,35 @@
+(ns my-app.portable
+  "Cross-platform namespace."
+  (:require [clojure.string :as str]
+            #?(:clj [clojure.java.io :as io]
+               :cljs [cljs.reader :as reader])))
+
+(defn shared-fn
+  "Works on all platforms."
+  [x]
+  (str/upper-case x))
+
+#?(:clj
+   (defn platform-fn
+     "JVM implementation."
+     [x]
+     (.toString x))
+   :cljs
+   (defn platform-fn
+     "JS implementation."
+     [x]
+     (str x)))
+
+#?(:clj
+   (def ^:private jvm-secret 42))
+
+#?(:clj
+   (defn clj-only
+     "JVM only function."
+     [x]
+     (Math/sqrt x))
+   :cljs
+   (defn cljs-only
+     "JS only function."
+     [x]
+     (js/Math.sqrt x)))

--- a/tests/fixtures/clojure/sample.clj
+++ b/tests/fixtures/clojure/sample.clj
@@ -1,0 +1,64 @@
+(ns my-app.core
+  "Application core namespace."
+  (:require [clojure.string :as str]
+            [clojure.set :refer [union intersection]]))
+
+(defprotocol Greetable
+  "Protocol for things that can greet."
+  (greet [this] "Returns a greeting string.")
+  (farewell [this]))
+
+(defrecord Person [name age]
+  Greetable
+  (greet [this] (str "Hello, I'm " name))
+  (farewell [this] (str "Goodbye from " name)))
+
+(deftype FastCounter [^:volatile-mutable cnt]
+  clojure.lang.IDeref
+  (deref [_] cnt))
+
+(defn hello
+  "Says hello to the given name."
+  [name]
+  (println (str "Hello, " name "!")))
+
+(defn- private-helper
+  "A private helper function."
+  [x]
+  (* x x))
+
+(def my-constant
+  "The answer to everything."
+  42)
+
+(def ^:private secret "hidden")
+
+(defonce db-connection
+  "Persistent database connection."
+  (atom nil))
+
+(defmacro unless
+  "Evaluates body when pred is falsy."
+  [pred & body]
+  `(when (not ~pred) ~@body))
+
+(defmulti area
+  "Calculate area based on shape type."
+  :shape)
+
+(defmethod area :circle
+  [{:keys [radius]}]
+  (* Math/PI radius radius))
+
+(defmethod area :rect
+  [{:keys [w h]}]
+  (* w h))
+
+;; A regular comment, should not be treated as docstring
+(defn no-docstring [x y]
+  (+ x y))
+
+(defn multi-arity
+  "Function with multiple arities."
+  ([x] (multi-arity x 1))
+  ([x y] (+ x y)))

--- a/tests/unit/mappers/clojure.test.ts
+++ b/tests/unit/mappers/clojure.test.ts
@@ -1,0 +1,312 @@
+import { writeFile, rm, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { SymbolKind } from "../../../src/enums.js";
+import { clojureMapper } from "../../../src/mappers/clojure.js";
+
+const FIXTURES_DIR = join(import.meta.dirname, "../../fixtures");
+const TMP_DIR = join(FIXTURES_DIR, "tmp");
+
+describe("clojureMapper", () => {
+  it("extracts ns, defn, def, and imports from fixture", async () => {
+    const filePath = join(FIXTURES_DIR, "clojure/sample.clj");
+    const result = await clojureMapper(filePath);
+
+    if (!result) {
+      // tree-sitter not available — skip gracefully
+      return;
+    }
+
+    expect(result.language).toBe("Clojure");
+    expect(result.symbols.length).toBeGreaterThan(0);
+
+    // Namespace
+    const ns = result.symbols.find((s) => s.kind === SymbolKind.Namespace);
+    expect(ns).toBeDefined();
+    expect(ns?.name).toBe("my-app.core");
+    expect(ns?.docstring).toBe("Application core namespace.");
+
+    // Imports
+    expect(result.imports).toContain("[clojure.string :as str]");
+    expect(result.imports).toContain(
+      "[clojure.set :refer [union intersection]]"
+    );
+  });
+
+  it("extracts defn with docstring and signature", async () => {
+    const filePath = join(FIXTURES_DIR, "clojure/sample.clj");
+    const result = await clojureMapper(filePath);
+    if (!result) {
+      return;
+    }
+
+    const hello = result.symbols.find((s) => s.name === "hello");
+    expect(hello).toBeDefined();
+    expect(hello?.kind).toBe(SymbolKind.Function);
+    expect(hello?.docstring).toBe("Says hello to the given name.");
+    expect(hello?.signature).toBe("(defn hello [name])");
+    expect(hello?.isExported).toBe(true);
+  });
+
+  it("marks defn- as private", async () => {
+    const filePath = join(FIXTURES_DIR, "clojure/sample.clj");
+    const result = await clojureMapper(filePath);
+    if (!result) {
+      return;
+    }
+
+    const helper = result.symbols.find((s) => s.name === "private-helper");
+    expect(helper).toBeDefined();
+    expect(helper?.kind).toBe(SymbolKind.Function);
+    expect(helper?.isExported).toBe(false);
+    expect(helper?.modifiers).toContain("private");
+  });
+
+  it("extracts def and defonce", async () => {
+    const filePath = join(FIXTURES_DIR, "clojure/sample.clj");
+    const result = await clojureMapper(filePath);
+    if (!result) {
+      return;
+    }
+
+    const constant = result.symbols.find((s) => s.name === "my-constant");
+    expect(constant).toBeDefined();
+    expect(constant?.kind).toBe(SymbolKind.Variable);
+    expect(constant?.docstring).toBe("The answer to everything.");
+    expect(constant?.isExported).toBe(true);
+
+    // ^:private metadata sets isExported=false and adds "private" modifier
+    const secret = result.symbols.find((s) => s.name === "secret");
+    expect(secret).toBeDefined();
+    expect(secret?.isExported).toBe(false);
+    expect(secret?.modifiers).toContain("private");
+
+    const conn = result.symbols.find((s) => s.name === "db-connection");
+    expect(conn).toBeDefined();
+    expect(conn?.kind).toBe(SymbolKind.Variable);
+    expect(conn?.docstring).toBe("Persistent database connection.");
+  });
+
+  it("extracts defmacro with macro modifier", async () => {
+    const filePath = join(FIXTURES_DIR, "clojure/sample.clj");
+    const result = await clojureMapper(filePath);
+    if (!result) {
+      return;
+    }
+
+    const unless = result.symbols.find((s) => s.name === "unless");
+    expect(unless).toBeDefined();
+    expect(unless?.kind).toBe(SymbolKind.Function);
+    expect(unless?.modifiers).toContain("macro");
+    expect(unless?.signature).toBe("(defmacro unless [pred & body])");
+  });
+
+  it("extracts defprotocol with method children", async () => {
+    const filePath = join(FIXTURES_DIR, "clojure/sample.clj");
+    const result = await clojureMapper(filePath);
+    if (!result) {
+      return;
+    }
+
+    const proto = result.symbols.find((s) => s.name === "Greetable");
+    expect(proto).toBeDefined();
+    expect(proto?.kind).toBe(SymbolKind.Interface);
+    expect(proto?.children).toBeDefined();
+    expect(proto?.children?.length).toBe(2);
+
+    const greet = proto?.children?.find((c) => c.name === "greet");
+    expect(greet).toBeDefined();
+    expect(greet?.kind).toBe(SymbolKind.Method);
+  });
+
+  it("extracts defrecord", async () => {
+    const filePath = join(FIXTURES_DIR, "clojure/sample.clj");
+    const result = await clojureMapper(filePath);
+    if (!result) {
+      return;
+    }
+
+    const person = result.symbols.find((s) => s.name === "Person");
+    expect(person).toBeDefined();
+    expect(person?.kind).toBe(SymbolKind.Class);
+    expect(person?.signature).toContain("[name age]");
+  });
+
+  it("extracts defmulti and defmethod", async () => {
+    const filePath = join(FIXTURES_DIR, "clojure/sample.clj");
+    const result = await clojureMapper(filePath);
+    if (!result) {
+      return;
+    }
+
+    const multi = result.symbols.find((s) => s.name === "area");
+    expect(multi).toBeDefined();
+    expect(multi?.kind).toBe(SymbolKind.Function);
+    expect(multi?.signature).toBe("(defmulti area :shape)");
+
+    const circle = result.symbols.find((s) => s.name === "area :circle");
+    expect(circle).toBeDefined();
+    expect(circle?.kind).toBe(SymbolKind.Method);
+
+    const rect = result.symbols.find((s) => s.name === "area :rect");
+    expect(rect).toBeDefined();
+    expect(rect?.kind).toBe(SymbolKind.Method);
+  });
+
+  it("extracts multi-arity function", async () => {
+    const filePath = join(FIXTURES_DIR, "clojure/sample.clj");
+    const result = await clojureMapper(filePath);
+    if (!result) {
+      return;
+    }
+
+    const multiArity = result.symbols.find((s) => s.name === "multi-arity");
+    expect(multiArity).toBeDefined();
+    expect(multiArity?.signature).toContain("[x]");
+    expect(multiArity?.signature).toContain("[x y]");
+  });
+
+  it("handles function without docstring", async () => {
+    const filePath = join(FIXTURES_DIR, "clojure/sample.clj");
+    const result = await clojureMapper(filePath);
+    if (!result) {
+      return;
+    }
+
+    const noDoc = result.symbols.find((s) => s.name === "no-docstring");
+    expect(noDoc).toBeDefined();
+    expect(noDoc?.docstring).toBeUndefined();
+  });
+
+  it("returns null for non-existent files", async () => {
+    const result = await clojureMapper("/non/existent/file.clj");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for empty files", async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    const filePath = join(TMP_DIR, "empty.clj");
+    await writeFile(filePath, "");
+
+    try {
+      const result = await clojureMapper(filePath);
+      expect(result).toBeNull();
+    } finally {
+      await rm(filePath, { force: true });
+    }
+  });
+
+  it("returns null for files with only comments", async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    const filePath = join(TMP_DIR, "comments.clj");
+    await writeFile(filePath, ";; just a comment\n;; another one\n");
+
+    try {
+      const result = await clojureMapper(filePath);
+      expect(result).toBeNull();
+    } finally {
+      await rm(filePath, { force: true });
+    }
+  });
+
+  it("extracts imports from ns with reader conditionals", async () => {
+    const filePath = join(FIXTURES_DIR, "clojure/reader_cond.cljc");
+    const result = await clojureMapper(filePath);
+    if (!result) {
+      return;
+    }
+
+    // Regular import
+    expect(result.imports).toContain("[clojure.string :as str]");
+
+    // Platform-specific imports unwrapped from #?()
+    expect(result.imports).toContain("[clojure.java.io :as io] :clj");
+    expect(result.imports).toContain("[cljs.reader :as reader] :cljs");
+  });
+
+  it("extracts defs from reader conditionals", async () => {
+    const filePath = join(FIXTURES_DIR, "clojure/reader_cond.cljc");
+    const result = await clojureMapper(filePath);
+    if (!result) {
+      return;
+    }
+
+    // Regular def should still be there
+    const shared = result.symbols.find((s) => s.name === "shared-fn");
+    expect(shared).toBeDefined();
+    expect(shared?.modifiers).toBeUndefined();
+
+    // Platform-specific defs from reader conditional
+    const platformFns = result.symbols.filter((s) => s.name === "platform-fn");
+    expect(platformFns).toHaveLength(2);
+
+    const cljVariant = platformFns.find((s) =>
+      s.modifiers?.includes("platform::clj")
+    );
+    expect(cljVariant).toBeDefined();
+    expect(cljVariant?.docstring).toBe("JVM implementation.");
+
+    const cljsVariant = platformFns.find((s) =>
+      s.modifiers?.includes("platform::cljs")
+    );
+    expect(cljsVariant).toBeDefined();
+    expect(cljsVariant?.docstring).toBe("JS implementation.");
+  });
+
+  it("extracts private defs inside reader conditionals", async () => {
+    const filePath = join(FIXTURES_DIR, "clojure/reader_cond.cljc");
+    const result = await clojureMapper(filePath);
+    if (!result) {
+      return;
+    }
+
+    const secret = result.symbols.find((s) => s.name === "jvm-secret");
+    expect(secret).toBeDefined();
+    expect(secret?.isExported).toBe(false);
+    expect(secret?.modifiers).toContain("private");
+    expect(secret?.modifiers).toContain("platform::clj");
+  });
+
+  it("extracts different names from different branches", async () => {
+    const filePath = join(FIXTURES_DIR, "clojure/reader_cond.cljc");
+    const result = await clojureMapper(filePath);
+    if (!result) {
+      return;
+    }
+
+    const cljOnly = result.symbols.find((s) => s.name === "clj-only");
+    expect(cljOnly).toBeDefined();
+    expect(cljOnly?.modifiers).toContain("platform::clj");
+
+    const cljsOnly = result.symbols.find((s) => s.name === "cljs-only");
+    expect(cljsOnly).toBeDefined();
+    expect(cljsOnly?.modifiers).toContain("platform::cljs");
+  });
+
+  it("extracts deftype", async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    const filePath = join(TMP_DIR, "deftype.clj");
+    await writeFile(
+      filePath,
+      `(deftype Counter [^:volatile-mutable cnt]
+  clojure.lang.IDeref
+  (deref [_] cnt))
+`
+    );
+
+    try {
+      const result = await clojureMapper(filePath);
+      if (!result) {
+        return;
+      }
+
+      const counter = result.symbols.find((s) => s.name === "Counter");
+      expect(counter).toBeDefined();
+      expect(counter?.kind).toBe(SymbolKind.Class);
+      expect(counter?.signature).toContain("[^:volatile-mutable cnt]");
+    } finally {
+      await rm(filePath, { force: true });
+    }
+  });
+});


### PR DESCRIPTION
Tree-sitter mapper for .clj, .cljs, .cljc, .edn files using `ghoseb/tree-sitter-clojure` (fork of the official clojure tree-sitter grammar with Node.js bindings).

Extracts: ns, defn, defn-, def, defonce, defmacro, defmulti, defmethod, defprotocol (with method children), defrecord, deftype.

Handles docstrings, ^:private metadata, multi-arity functions, reader conditionals (#?/#?@) for both top-level defs and ns imports.